### PR TITLE
Target AspNetCore 2.1-preview2 as there is an API change required

### DIFF
--- a/samples/Sandbox/Sandbox.csproj
+++ b/samples/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core support for multitenant DI via Autofac.Multitenant.</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <VersionPrefix>2.0.0-preview2</VersionPrefix>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Integration.AspNetCore.Multitenant</AssemblyName>
@@ -28,14 +28,12 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Autofac.Multitenant" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.2.0-beta2">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesMiddleware.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesMiddleware.cs
@@ -58,7 +58,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant
                 throw new InvalidOperationException(Properties.Resources.NoMultitenantContainerAvailable);
             }
 
-            using (var feature = new RequestServicesFeature(container.Resolve<IServiceScopeFactory>()))
+            using (var feature = new RequestServicesFeature(context, container.Resolve<IServiceScopeFactory>()))
             {
                 var existingFeature = context.Features.Get<IServiceProvidersFeature>();
                 try

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0-preview2-final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
I'm using AspNetCore and just updated to 2.1-preview2, which caused a runtime exception. I've made the simple changes to enable building against .NET Core 2.1 and also updated some of the analyser packages to fix for breakage as I am also using 15.7-preview3.