### PR TITLE
Add support for ASP.NET Core 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+
+# Rider crap
+.idea

--- a/Autofac.AspNetCore.Multitenant.sln
+++ b/Autofac.AspNetCore.Multitenant.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Integration.AspNetCore.Multitenant", "src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj", "{241CD558-86C8-493B-9FA1-D913167D527C}"
 EndProject
@@ -9,11 +9,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Integration.AspNetC
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E5744E19-4490-4073-91F9-6E828FA6C2E1}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		build.ps1 = build.ps1
+		global.json = global.json
+		NuGet.Config = NuGet.Config
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox", "samples\Sandbox\Sandbox.csproj", "{12445470-D348-467F-8D3F-FBD6EF525CEE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8C9BBEEC-0C4B-4ECD-B927-63899C265FB4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5227B99C-6D0F-4E7B-9DF8-82C53488E173}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{BD3275CD-8B4C-4CEA-8DDB-BEF386DD48B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,5 +47,13 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{241CD558-86C8-493B-9FA1-D913167D527C} = {8C9BBEEC-0C4B-4ECD-B927-63899C265FB4}
+		{BA923A91-3A4B-40CE-8788-70A641694945} = {5227B99C-6D0F-4E7B-9DF8-82C53488E173}
+		{12445470-D348-467F-8D3F-FBD6EF525CEE} = {BD3275CD-8B4C-4CEA-8DDB-BEF386DD48B5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {86C0AA9A-D4DE-4954-A10C-5CEF56C5A8D1}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="AutofacMyGet" value="https://www.myget.org/F/autofac/api/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.2.103"
+    "version": "3.0.100-preview8-013656"
   }
 }

--- a/samples/Sandbox/Program.cs
+++ b/samples/Sandbox/Program.cs
@@ -1,17 +1,20 @@
-﻿using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 
 namespace Sandbox
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            var host = WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+            var host = Host.CreateDefaultBuilder(args)
+                .UseServiceProviderFactory(new AutofacMultitenantServiceProviderFactory(Startup.ConfigureMultitenantContainer))
+                .ConfigureWebHostDefaults(webHostBuilder => webHostBuilder.UseStartup<Startup>())
                 .Build();
 
-            host.Run();
+
+            await host.RunAsync();
         }
     }
 }

--- a/samples/Sandbox/Sandbox.csproj
+++ b/samples/Sandbox/Sandbox.csproj
@@ -1,21 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="wwwroot\**" />
-    <Content Remove="wwwroot\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
-    <None Remove="wwwroot\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj" />
   </ItemGroup>

--- a/samples/Sandbox/Startup.cs
+++ b/samples/Sandbox/Startup.cs
@@ -12,54 +12,55 @@ using Microsoft.Extensions.Logging;
 
 namespace Sandbox
 {
+
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            this.Configuration = configuration;
-        }
-
-        private MultitenantContainer ApplicationContainer { get; set; }
-
-        public IConfiguration Configuration { get; }
-
         public void Configure(IApplicationBuilder app)
         {
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseEndpoints(builder => builder.MapControllers());
         }
 
-        public IServiceProvider ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddAutofacMultitenantRequestServices(() => ApplicationContainer)
-                .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-            
-            var builder = new ContainerBuilder();
-            builder.Populate(services);
+                .AddAutofacMultitenantRequestServices()
+                .AddControllers()
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+        }
+
+        public void ConfigureContainer(ContainerBuilder builder)
+        {
             builder.RegisterType<Dependency>()
                 .As<IDependency>()
                 .WithProperty("Id", "base")
                 .InstancePerLifetimeScope();
-            var container = builder.Build();
-            var strategy = new QueryStringTenantIdentificationStrategy(container.Resolve<IHttpContextAccessor>(), container.Resolve<ILogger<QueryStringTenantIdentificationStrategy>>());
-            var mtc = new MultitenantContainer(strategy, container);
-            mtc.ConfigureTenant(
+        }
+
+        public static MultitenantContainer ConfigureMultitenantContainer(IContainer container)
+        {
+            var strategy = new QueryStringTenantIdentificationStrategy(container.Resolve<IHttpContextAccessor>(),
+                container.Resolve<ILogger<QueryStringTenantIdentificationStrategy>>());
+
+            var multitenantContainer = new MultitenantContainer(strategy, container);
+
+            multitenantContainer.ConfigureTenant(
                 "a",
                 cb => cb
-                        .RegisterType<Dependency>()
-                        .As<IDependency>()
-                        .WithProperty("Id", "a")
-                        .InstancePerLifetimeScope());
-            mtc.ConfigureTenant(
+                    .RegisterType<Dependency>()
+                    .As<IDependency>()
+                    .WithProperty("Id", "a")
+                    .InstancePerLifetimeScope());
+            multitenantContainer.ConfigureTenant(
                 "b",
                 cb => cb
-                        .RegisterType<Dependency>()
-                        .As<IDependency>()
-                        .WithProperty("Id", "b")
-                        .InstancePerLifetimeScope());
-            ApplicationContainer = mtc;
-            return new AutofacServiceProvider(mtc);
+                    .RegisterType<Dependency>()
+                    .As<IDependency>()
+                    .WithProperty("Id", "b")
+                    .InstancePerLifetimeScope());
+
+            return multitenantContainer;
         }
     }
 }

--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core support for multitenant DI via Autofac.Multitenant.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0; netcoreapp3.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Integration.AspNetCore.Multitenant</AssemblyName>
@@ -28,10 +28,17 @@
     <Product>Autofac</Product>
   </PropertyGroup>
 
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Autofac.Multitenant" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.0-develop-00407" />
+    <PackageReference Include="Autofac.Multitenant" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -41,10 +48,10 @@
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.6.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceCollectionExtensions.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceCollectionExtensions.cs
@@ -24,8 +24,10 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using Autofac;
 using Autofac.Integration.AspNetCore.Multitenant;
 using Autofac.Multitenant;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -42,24 +44,15 @@ namespace Microsoft.AspNetCore.Hosting
         /// scope generation.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> instance being configured.</param>
-        /// <param name="multitenantContainerAccessor">A function that will access the multitenant container from which request lifetimes should be generated.</param>
         /// <returns>The existing <see cref="IServiceCollection"/> instance.</returns>
         /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="services" /> or <paramref name="multitenantContainerAccessor" /> is <see langword="null" />.
+        /// Thrown if <paramref name="services" /> is <see langword="null" />.
         /// </exception>
-        public static IServiceCollection AddAutofacMultitenantRequestServices(this IServiceCollection services, Func<MultitenantContainer> multitenantContainerAccessor)
+        public static IServiceCollection AddAutofacMultitenantRequestServices(this IServiceCollection services)
         {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+            if (services == null) throw new ArgumentNullException(nameof(services));
 
-            if (multitenantContainerAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(multitenantContainerAccessor));
-            }
-
-            services.Insert(0, ServiceDescriptor.Transient<IStartupFilter>(provider => new MultitenantRequestServicesStartupFilter(multitenantContainerAccessor)));
+            services.Insert(0, ServiceDescriptor.Transient<IStartupFilter>(provider => new MultitenantRequestServicesStartupFilter()));
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             return services;

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProvider.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProvider.cs
@@ -1,5 +1,5 @@
 ﻿// This software is part of the Autofac IoC container
-// Copyright © 2017 Autofac Contributors
+// Copyright © 2019 Autofac Contributors
 // https://autofac.org
 //
 // Permission is hereby granted, free of charge, to any person
@@ -24,34 +24,24 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using Autofac;
+using Autofac.Extensions.DependencyInjection;
 using Autofac.Multitenant;
 
-namespace Microsoft.AspNetCore.Hosting
+namespace Autofac.Integration.AspNetCore.Multitenant
 {
     /// <summary>
-    /// Extension methods for the <see cref="IWebHostBuilder"/> interface.
+    /// Autofac implementation of the ASP.NET Core <see cref="IServiceProvider"/> for a <see cref="MultitenantContainer" />.
     /// </summary>
-    public static class AutofacMultitenantWebHostBuilderExtensions
+    /// <seealso cref="IServiceProvider" />
+    public sealed class AutofacMultitenantServiceProvider : AutofacServiceProvider
     {
         /// <summary>
-        /// Adds the multitenant Autofac request services middleware, which ensures request lifetimes spawn from the container
-        /// rather than a pre-resolved tenant lifetime scope. This allows tenant identification to occur at the time of request
-        /// scope generation.
+        /// Initializes a new instance of the <see cref="AutofacMultitenantServiceProvider"/> class.
         /// </summary>
-        /// <param name="builder">The <see cref="IWebHostBuilder"/> instance being configured.</param>
-        /// <returns>The existing <see cref="IWebHostBuilder"/> instance.</returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder" /> is <see langword="null" />.
-        /// </exception>
-        public static IWebHostBuilder UseAutofacMultitenantRequestServices(this IWebHostBuilder builder)
+        /// <param name="lifetimeScope">The <see cref="ILifetimeScope"/> in form of a <see cref="MultitenantContainer"/>.</param>
+        public AutofacMultitenantServiceProvider(ILifetimeScope lifetimeScope)
+            : base(lifetimeScope)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
-
-            return builder.ConfigureServices(services =>
-            {
-                services.AddAutofacMultitenantRequestServices();
-            });
         }
     }
 }

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProviderFactory.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProviderFactory.cs
@@ -1,0 +1,101 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2019 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Extensions.DependencyInjection;
+using Autofac.Integration.AspNetCore.Multitenant;
+using Autofac.Integration.AspNetCore.Multitenant.Properties;
+using Autofac.Multitenant;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// A factory for creating a <see cref="ContainerBuilder"/> and an <see cref="IServiceProvider" /> for usage with a <see cref="MultitenantContainer" /> in ASP.NET Core.
+    /// </summary>
+    public class AutofacMultitenantServiceProviderFactory : IServiceProviderFactory<ContainerBuilder>
+    {
+        private readonly Action<ContainerBuilder> _configurationAction;
+        private readonly Func<IContainer, MultitenantContainer> _multitenantContainerAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacMultitenantServiceProviderFactory"/> class.
+        /// </summary>
+        /// <param name="multitenantContainerAccessor">A function that will access the multitenant container from which request lifetimes should be generated.</param>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the conatiner.</param>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        /// Thrown if <paramref name="multitenantContainerAccessor" /> is <see langword="null" />.
+        public AutofacMultitenantServiceProviderFactory(Func<IContainer, MultitenantContainer> multitenantContainerAccessor, Action<ContainerBuilder> configurationAction = null)
+        {
+            this._multitenantContainerAccessor = multitenantContainerAccessor ?? throw new ArgumentNullException(nameof(multitenantContainerAccessor));
+            this._configurationAction = configurationAction ?? (builder => { });
+        }
+
+        /// <summary>
+        /// Creates a container builder from an <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The collection of services.</param>
+        /// <returns>A container builder that can be used to create an <see cref="IServiceProvider" />.</returns>
+        public ContainerBuilder CreateBuilder(IServiceCollection services)
+        {
+            var builder = new ContainerBuilder();
+
+            builder.Populate(services);
+
+            this._configurationAction(builder);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IServiceProvider" /> from the container builder.
+        /// </summary>
+        /// <param name="containerBuilder">The container builder.</param>
+        /// <returns>An <see cref="IServiceProvider" />.</returns>
+        public IServiceProvider CreateServiceProvider(ContainerBuilder containerBuilder)
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+
+            AutofacMultitenantServiceProvider provider = null;
+
+            containerBuilder.Register(_ => provider)
+                .As<IServiceProvider>()
+                .ExternallyOwned();
+
+            var multitenantContainer = this._multitenantContainerAccessor(containerBuilder.Build());
+
+            if (multitenantContainer == null) throw new InvalidOperationException(Resources.NoMultitenantContainerAvailable);
+
+            provider = new AutofacMultitenantServiceProvider(multitenantContainer);
+
+            return provider;
+        }
+    }
+}

--- a/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesStartupFilter.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesStartupFilter.cs
@@ -15,23 +15,6 @@ namespace Autofac.Integration.AspNetCore.Multitenant
     internal class MultitenantRequestServicesStartupFilter : IStartupFilter
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MultitenantRequestServicesStartupFilter"/> class.
-        /// </summary>
-        /// <param name="multitenantContainerAccessor">A function that will access the multitenant container from which request lifetimes should be generated.</param>
-        public MultitenantRequestServicesStartupFilter(Func<MultitenantContainer> multitenantContainerAccessor)
-        {
-            this.MultitenantContainerAccessor = multitenantContainerAccessor;
-        }
-
-        /// <summary>
-        /// Gets the multitenant container accessor.
-        /// </summary>
-        /// <value>
-        /// A function that will access the multitenant container from which request lifetimes should be generated.
-        /// </value>
-        public Func<MultitenantContainer> MultitenantContainerAccessor { get; private set; }
-
-        /// <summary>
         /// Adds the multitenant request services middleware to the app pipeline.
         /// </summary>
         /// <param name="next">
@@ -44,7 +27,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant
         {
             return builder =>
             {
-                builder.UseMiddleware<MultitenantRequestServicesMiddleware>(this.MultitenantContainerAccessor);
+                builder.UseMiddleware<MultitenantRequestServicesMiddleware>();
                 next(builder);
             };
         }

--- a/src/Autofac.Integration.AspNetCore.Multitenant/RequestServicesFeatureFactory.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/RequestServicesFeatureFactory.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using Microsoft.AspNetCore.Hosting.Internal;
+using Autofac.Integration.AspNetCore.Multitenant.Properties;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Hosting.Internal;
+#endif
 
 namespace Autofac.Integration.AspNetCore.Multitenant
 {
@@ -50,7 +52,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant
                         factoryParameter)
                         .Compile();
                 default:
-                    throw new NotSupportedException(Properties.Resources.NoSupportedRequestServicesConstructorFound);
+                    throw new NotSupportedException(Resources.NoSupportedRequestServicesConstructorFound);
             }
         }
     }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -21,19 +21,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190808-03" />
+    <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0-preview8.19405.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0-preview8.19405.4" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview8.19405.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceCollectionExtensionsTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceCollectionExtensionsTests.cs
@@ -15,8 +15,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         {
             var services = new ServiceCollection();
 
-            var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            services.AddAutofacMultitenantRequestServices(() => mtc);
+            services.AddAutofacMultitenantRequestServices();
 
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
@@ -29,8 +28,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         {
             var services = new ServiceCollection();
 
-            var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            services.AddAutofacMultitenantRequestServices(() => mtc);
+            services.AddAutofacMultitenantRequestServices();
 
             var serviceProvider = services.BuildServiceProvider();
             var filter = serviceProvider.GetRequiredService<IStartupFilter>();
@@ -42,13 +40,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         public void AddAutofacMultitenantRequestServices_NullBuilder()
         {
             var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantServiceCollectionExtensions.AddAutofacMultitenantRequestServices(null, () => mtc));
-        }
-
-        [Fact]
-        public void AddAutofacMultitenantRequestServices_NullContainerAccessor()
-        {
-            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantServiceCollectionExtensions.AddAutofacMultitenantRequestServices(new ServiceCollection(), null));
+            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantServiceCollectionExtensions.AddAutofacMultitenantRequestServices(null));
         }
     }
 }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantWebHostBuilderExtensionsTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantWebHostBuilderExtensionsTests.cs
@@ -20,8 +20,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
                 .Setup(x => x.ConfigureServices(It.IsAny<Action<IServiceCollection>>()))
                 .Callback<Action<IServiceCollection>>(s => s(services));
 
-            var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            webHostBuilder.Object.UseAutofacMultitenantRequestServices(() => mtc);
+            webHostBuilder.Object.UseAutofacMultitenantRequestServices();
 
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetService<IHttpContextAccessor>();
@@ -39,8 +38,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
                 .Setup(x => x.ConfigureServices(It.IsAny<Action<IServiceCollection>>()))
                 .Callback<Action<IServiceCollection>>(s => s(services));
 
-            var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            webHostBuilder.Object.UseAutofacMultitenantRequestServices(() => mtc);
+            webHostBuilder.Object.UseAutofacMultitenantRequestServices();
 
             var serviceProvider = services.BuildServiceProvider();
             var filter = serviceProvider.GetService<IStartupFilter>();
@@ -52,14 +50,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         public void UseAutofacMultitenantRequestServices_NullBuilder()
         {
             var mtc = new MultitenantContainer(Mock.Of<ITenantIdentificationStrategy>(), new ContainerBuilder().Build());
-            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantWebHostBuilderExtensions.UseAutofacMultitenantRequestServices(null, () => mtc));
-        }
-
-        [Fact]
-        public void UseAutofacMultitenantRequestServices_NullContainerAccessor()
-        {
-            var builder = Mock.Of<IWebHostBuilder>();
-            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantWebHostBuilderExtensions.UseAutofacMultitenantRequestServices(builder, null));
+            Assert.Throws<ArgumentNullException>(() => AutofacMultitenantWebHostBuilderExtensions.UseAutofacMultitenantRequestServices(null));
         }
     }
 }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/HostedMultitenancyTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/HostedMultitenancyTests.cs
@@ -7,19 +7,28 @@ using Autofac.Multitenant;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+#if NETCOREAPP3_0
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Autofac.Integration.AspNetCore.Multitenant.Test
 {
-    public sealed class HostedMultitenancyTests
+    public sealed class HostedMultitenancyTests : IClassFixture<TestServerFixture>
     {
+        private readonly TestServerFixture _testServerFixture;
+
+        public HostedMultitenancyTests(TestServerFixture testServerFixture)
+        {
+            this._testServerFixture = testServerFixture;
+        }
+
         [Fact]
         public async Task CallRootEndpoint_HasTheCorrectDependenciesAndResponseIsBase()
         {
-            var client = GetApplicationClient();
+            var client = this._testServerFixture.GetApplicationClient();
 
             var response = await client.GetAsync("root-endpoint");
 
@@ -32,7 +41,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         [InlineData("b", "b")]
         public async Task CallTenantEndpoint_HasTheCorrectDependenciesAndResponseIsTenantItself(string tenantQuery, string expectedTenantId)
         {
-            var client = GetApplicationClient();
+            var client = this._testServerFixture.GetApplicationClient();
 
             var response = await client.GetAsync($"tenant-endpoint?tenant={tenantQuery}");
 
@@ -44,7 +53,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         [InlineData("tenant-does-not-exist")]
         public async Task CallTenantEndpoint_WithNonExistantTenantReturns404(string tenantQuery)
         {
-            var client = GetApplicationClient();
+            var client = this._testServerFixture.GetApplicationClient();
 
             var response = await client.GetAsync($"tenant-endpoint?tenant={tenantQuery}");
 
@@ -58,163 +67,12 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
         [InlineData("b", "b")]
         public async Task CallGenericEndpoint_HasTheCorrectDependenciesAndResponseIsTenantOrBase(string tenantQuery, string expectedTenantId)
         {
-            var client = GetApplicationClient();
+            var client = this._testServerFixture.GetApplicationClient();
 
             var response = await client.GetAsync($"supports-with-and-without-tenant?tenant={tenantQuery}");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(expectedTenantId, await response.Content.ReadAsStringAsync());
-        }
-
-        private static HttpClient GetApplicationClient()
-        {
-            var server = new TestServer(new WebHostBuilder()
-                .UseStartup<Startup>());
-
-            return server.CreateClient();
-        }
-
-        private sealed class Startup
-        {
-            private MultitenantContainer _applicationContainer;
-
-            public IServiceProvider ConfigureServices(IServiceCollection services)
-            {
-                services
-                    .AddAutofacMultitenantRequestServices(() => _applicationContainer)
-                    .AddTransient(provider => new WhoAmIDependency("base"))
-                    .AddSingleton<ITenantIdentificationStrategy, TestableTenantIdentificationStrategy>()
-                    .AddSingleton<ITenantAccessor, TenantAccessorDependency>()
-                    .AddRouting();
-
-                var builder = new ContainerBuilder();
-                builder.Populate(services);
-                var container = builder.Build();
-
-                var strategy = container.Resolve<ITenantIdentificationStrategy>();
-                var mtc = new MultitenantContainer(strategy, container);
-
-                mtc.ConfigureTenant(
-                    "a",
-                    cb => cb
-                        .RegisterType<WhoAmIDependency>()
-                        .WithParameter("id", "a")
-                        .InstancePerLifetimeScope());
-                mtc.ConfigureTenant(
-                    "b",
-                    cb => cb
-                        .RegisterType<WhoAmIDependency>()
-                        .WithParameter("id", "b")
-                        .InstancePerLifetimeScope());
-
-                _applicationContainer = mtc;
-                return new AutofacServiceProvider(mtc);
-            }
-
-            public void Configure(IApplicationBuilder builder)
-            {
-                builder.UseRouter(routeBuilder =>
-                {
-                    routeBuilder.MapGet("root-endpoint", async context =>
-                    {
-                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
-                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
-                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
-
-                        Assert.Equal("base", whoAmI.Id);
-                        Assert.Null(tenantAccessor.CurrentTenant);
-                        Assert.False(strategy.TryIdentifyTenant(out var tenantId));
-                        Assert.Null(tenantId);
-
-                        await context.Response.WriteAsync(whoAmI.Id);
-                    });
-
-                    routeBuilder.MapGet("tenant-endpoint", async context =>
-                    {
-                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
-                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
-                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
-
-                        if (whoAmI.Id == "base")
-                        {
-                            context.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                            return;
-                        }
-
-                        Assert.Equal(tenantAccessor.CurrentTenant, whoAmI.Id);
-                        Assert.NotEqual("base", tenantAccessor.CurrentTenant);
-                        Assert.True(strategy.TryIdentifyTenant(out var tenantId));
-                        Assert.NotEqual("base", tenantId);
-                        Assert.Equal(tenantId, tenantAccessor.CurrentTenant);
-                        Assert.Equal(tenantId, whoAmI.Id);
-
-                        await context.Response.WriteAsync(tenantAccessor.CurrentTenant);
-                    });
-
-                    routeBuilder.MapGet("supports-with-and-without-tenant", async context =>
-                    {
-                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
-                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
-                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
-
-                        Assert.True(strategy.TryIdentifyTenant(out var tenantId));
-                        Assert.Equal(tenantId, tenantAccessor.CurrentTenant);
-
-                        await context.Response.WriteAsync(whoAmI.Id);
-                    });
-                });
-            }
-
-            private interface ITenantAccessor
-            {
-                string CurrentTenant { get; }
-            }
-
-            private sealed class TenantAccessorDependency : ITenantAccessor
-            {
-                public string CurrentTenant { get; }
-
-                public TenantAccessorDependency(ITenantIdentificationStrategy tenantIdentificationStrategy)
-                {
-                    if (tenantIdentificationStrategy.TryIdentifyTenant(out var tenantId) &&
-                        tenantId is string currentTenant)
-                    {
-                        CurrentTenant = currentTenant;
-                    }
-                }
-            }
-
-            private sealed class WhoAmIDependency
-            {
-                public string Id { get; }
-
-                public WhoAmIDependency(string id)
-                {
-                    Id = id;
-                }
-            }
-
-            private sealed class TestableTenantIdentificationStrategy : ITenantIdentificationStrategy
-            {
-                private readonly IHttpContextAccessor _httpContextAccessor;
-
-                public TestableTenantIdentificationStrategy(IHttpContextAccessor httpContextAccessor)
-                {
-                    _httpContextAccessor = httpContextAccessor;
-                }
-
-                public bool TryIdentifyTenant(out object tenantId)
-                {
-                    if (_httpContextAccessor.HttpContext?.Request.Query.TryGetValue("tenant", out var tenantValues) ?? false)
-                    {
-                        tenantId = tenantValues[0];
-                        return true;
-                    }
-
-                    tenantId = null;
-                    return false;
-                }
-            }
         }
     }
 }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/MultitenantRequestServicesMiddlewareTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/MultitenantRequestServicesMiddlewareTests.cs
@@ -21,7 +21,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
             var next = new RequestDelegate(ctx => Task.FromResult(0));
             var context = CreateContext();
 
-            var mw = new MultitenantRequestServicesMiddleware(next, () => mtc, accessor);
+            var mw = new MultitenantRequestServicesMiddleware(next, accessor, new AutofacMultitenantServiceProvider(mtc));
             await mw.Invoke(context);
             Assert.NotSame(context, accessor.HttpContext);
         }
@@ -33,7 +33,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
             var next = new RequestDelegate(ctx => Task.FromResult(0));
             var context = CreateContext();
 
-            var mw = new MultitenantRequestServicesMiddleware(next, () => null, accessor);
+            var mw = new MultitenantRequestServicesMiddleware(next, accessor, new AutofacServiceProvider(new ContainerBuilder().Build()));
             await Assert.ThrowsAsync<InvalidOperationException>(() => mw.Invoke(context));
         }
 
@@ -54,7 +54,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
             var context = CreateContext();
             context.Features.Set<IServiceProvidersFeature>(originalFeature);
 
-            var mw = new MultitenantRequestServicesMiddleware(next, () => mtc, accessor);
+            var mw = new MultitenantRequestServicesMiddleware(next, accessor, new AutofacMultitenantServiceProvider(mtc));
             await mw.Invoke(context);
 
             // The original request services feature should have been replaced
@@ -71,7 +71,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test
             var next = new RequestDelegate(ctx => Task.FromResult(0));
             var context = CreateContext();
 
-            var mw = new MultitenantRequestServicesMiddleware(next, () => mtc, accessor);
+            var mw = new MultitenantRequestServicesMiddleware(next, accessor, new AutofacMultitenantServiceProvider(mtc));
             await mw.Invoke(context);
             Assert.Same(context, accessor.HttpContext);
         }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestServerFixture.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestServerFixture.cs
@@ -1,0 +1,175 @@
+﻿using System.Net;
+using System.Net.Http;
+using Autofac.Multitenant;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Autofac.Integration.AspNetCore.Multitenant.Test
+{
+    public class TestServerFixture
+    {
+        public HttpClient GetApplicationClient()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<Startup>()
+                .ConfigureServices(sp =>
+                    sp.AddSingleton<IServiceProviderFactory<ContainerBuilder>>(
+                        new AutofacMultitenantServiceProviderFactory(Startup.CreateMultitenantContainer)));
+
+            var testServer = new TestServer(webHostBuilder);
+
+            return testServer.CreateClient();
+        }
+
+        private sealed class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services
+                    .AddAutofacMultitenantRequestServices()
+                    .AddTransient(provider => new WhoAmIDependency("base"))
+                    .AddSingleton<ITenantAccessor, TenantAccessorDependency>()
+                    .AddSingleton<ITenantIdentificationStrategy, TestableTenantIdentificationStrategy>()
+                    .AddRouting();
+            }
+
+            public void ConfigureContainer(ContainerBuilder builder)
+            {
+            }
+
+            public static MultitenantContainer CreateMultitenantContainer(IContainer container)
+            {
+                var strategy = container.Resolve<ITenantIdentificationStrategy>();
+
+                var mtc = new MultitenantContainer(strategy, container);
+
+                mtc.ConfigureTenant(
+                    "a",
+                    cb => cb
+                        .RegisterType<WhoAmIDependency>()
+                        .WithParameter("id", "a")
+                        .InstancePerLifetimeScope());
+                mtc.ConfigureTenant(
+                    "b",
+                    cb => cb
+                        .RegisterType<WhoAmIDependency>()
+                        .WithParameter("id", "b")
+                        .InstancePerLifetimeScope());
+
+                return mtc;
+            }
+
+            public void Configure(IApplicationBuilder builder)
+            {
+                builder.UseRouter(routeBuilder =>
+                {
+                    routeBuilder.MapGet("root-endpoint", async context =>
+                    {
+                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
+                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
+                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
+
+                        Assert.Equal("base", whoAmI.Id);
+                        Assert.Null(tenantAccessor.CurrentTenant);
+                        Assert.False(strategy.TryIdentifyTenant(out var tenantId));
+                        Assert.Null(tenantId);
+
+                        await context.Response.WriteAsync(whoAmI.Id);
+                    });
+
+                    routeBuilder.MapGet("tenant-endpoint", async context =>
+                    {
+                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
+                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
+                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
+
+                        if (whoAmI.Id == "base")
+                        {
+                            context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                            return;
+                        }
+
+                        Assert.Equal(tenantAccessor.CurrentTenant, whoAmI.Id);
+                        Assert.NotEqual("base", tenantAccessor.CurrentTenant);
+                        Assert.True(strategy.TryIdentifyTenant(out var tenantId));
+                        Assert.NotEqual("base", tenantId);
+                        Assert.Equal(tenantId, tenantAccessor.CurrentTenant);
+                        Assert.Equal(tenantId, whoAmI.Id);
+
+                        await context.Response.WriteAsync(tenantAccessor.CurrentTenant);
+                    });
+
+                    routeBuilder.MapGet("supports-with-and-without-tenant", async context =>
+                    {
+                        var whoAmI = context.RequestServices.GetRequiredService<WhoAmIDependency>();
+                        var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
+                        var strategy = context.RequestServices.GetRequiredService<ITenantIdentificationStrategy>();
+
+                        Assert.True(strategy.TryIdentifyTenant(out var tenantId));
+                        Assert.Equal(tenantId, tenantAccessor.CurrentTenant);
+
+                        await context.Response.WriteAsync(whoAmI.Id);
+                    });
+                });
+            }
+
+            private interface ITenantAccessor
+            {
+                string CurrentTenant { get; }
+            }
+
+            private sealed class TenantAccessorDependency : ITenantAccessor
+            {
+                public string CurrentTenant { get; }
+
+                public TenantAccessorDependency(ITenantIdentificationStrategy tenantIdentificationStrategy)
+                {
+                    if (tenantIdentificationStrategy.TryIdentifyTenant(out var tenantId) &&
+                        tenantId is string currentTenant)
+                    {
+                        CurrentTenant = currentTenant;
+                    }
+                }
+            }
+
+            private sealed class WhoAmIDependency
+            {
+                public string Id { get; }
+
+                public WhoAmIDependency(string id)
+                {
+                    Id = id;
+                }
+            }
+
+            private sealed class TestableTenantIdentificationStrategy : ITenantIdentificationStrategy
+            {
+                private readonly IHttpContextAccessor _httpContextAccessor;
+
+                public TestableTenantIdentificationStrategy(IHttpContextAccessor httpContextAccessor)
+                {
+                    _httpContextAccessor = httpContextAccessor;
+                }
+
+                public bool TryIdentifyTenant(out object tenantId)
+                {
+                    if (_httpContextAccessor.HttpContext?.Request.Query.TryGetValue("tenant", out var tenantValues) ??
+                        false)
+                    {
+                        tenantId = tenantValues[0];
+                        return true;
+                    }
+
+                    tenantId = null;
+                    return false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is adding support for ASP.NET Core 3, introducing breaking changes for older versions of ASP.NET Core but still supports them.

* add multitargeting to framework `netstandard2.0` and `netcoreapp3.0`
* update `Autofac*` peer dependencies, some of them currently previews from autofac-myget
* change multitenant-container accessor to require an instance of `IContainer` that can be passed to it and is now only being used in `AutofacMultitenantServiceProviderFactory`
* create `AutofacMultitenantServiceProviderFactory` and capture the create service-provider in a closure registration
* move test-host configuration into `TestServerFixture`
* adapt changes in tests

Related to #9 and [#36](https://github.com/autofac/Autofac.Extensions.DependencyInjection/issues/36).