### PR TITLE
Update Autofac.Extensions.DependencyInjection to 5.0.0

### DIFF
--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.0-rc2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Autofac.Multitenant" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <PrivateAssets>All</PrivateAssets>


### PR DESCRIPTION
This PR...

* only updates `Autofac.Extensions.DependencyInjection` to 5.0.0 so we can release 2.0.0 of `Autofac.AspNetCore.Multitenant`