### PR TITLE
chore: apply latest stylecop rules

### DIFF
--- a/Autofac.AspNetCore.Multitenant.sln
+++ b/Autofac.AspNetCore.Multitenant.sln
@@ -38,6 +38,7 @@ ProjectSection(SolutionItems) = preProject
 	build\Autofac.Build.psm1 = build\Autofac.Build.psm1
 	build\CodeAnalysisDictionary.xml = build\CodeAnalysisDictionary.xml
 	build\icon.png = build\icon.png
+	build\stylecop.json = build\stylecop.json
 EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox.AspNetCore5", "samples\Sandbox.AspNetCore5\Sandbox.AspNetCore5.csproj", "{B64B6D62-AD07-49BE-AF65-3E4C92284AD5}"

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="14.0">
-  <!-- https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Do not directly await a task without calling ConfigureAwait - we need the context for HttpContext.Current and other context propagation. -->
-    <Rule Id="CA2007" Action="None" />
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+    <Rule Id="CA1032" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <Rule Id="CA1716" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
     <Rule Id="CA2237" Action="None" />
+    <!-- ConfigureAwait(false) is not required in ASP.NET Core. There is so SynchronizationContext. -->
+    <Rule Id="CA2007" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this -->
@@ -19,39 +22,9 @@
     <Rule Id="SA1122" Action="None" />
     <!-- Using statements must be inside a namespace -->
     <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
     <!-- Fields can't start with underscore -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
     <!-- No single-line statements involving braces -->
     <Rule Id="SA1501" Action="None" />
-    <!-- Braces must not be omitted -->
-    <Rule Id="SA1503" Action="None" />
-    <!-- Element must be documented -->
-    <Rule Id="SA1600" Action="None" />
-    <!-- Parameter documentation mus be in the right order -->
-    <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- File must have header -->
-    <Rule Id="SA1633" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Autofac Project",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} License. See {licenseFile} in the project root for license information.",
+      "variables": {
+        "licenseFile": "LICENSE",
+        "licenseName": "MIT"
+      },
+      "xmlHeader": false
+    }
+  }
+}

--- a/samples/Sandbox.AspNetCore2_1_To_2_2/Program.cs
+++ b/samples/Sandbox.AspNetCore2_1_To_2_2/Program.cs
@@ -1,11 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
 using Autofac;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Sandbox.Shared;
 
-namespace Sandbox.AspNetCore2_1_To_2_2
+namespace Sandbox
 {
     public static class Program
     {

--- a/samples/Sandbox.AspNetCore2_1_To_2_2/Sandbox.AspNetCore2_1_To_2_2.csproj
+++ b/samples/Sandbox.AspNetCore2_1_To_2_2/Sandbox.AspNetCore2_1_To_2_2.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+      <TargetFramework>netcoreapp2.1</TargetFramework>
+      <RootNamespace>Sandbox</RootNamespace>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />
-  </ItemGroup>
-
+    <ItemGroup>
+      <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
 </Project>

--- a/samples/Sandbox.AspNetCore2_1_To_2_2/Sandbox.AspNetCore2_1_To_2_2.csproj
+++ b/samples/Sandbox.AspNetCore2_1_To_2_2/Sandbox.AspNetCore2_1_To_2_2.csproj
@@ -2,10 +2,16 @@
     <PropertyGroup>
       <TargetFramework>netcoreapp2.1</TargetFramework>
       <RootNamespace>Sandbox</RootNamespace>
+      <NoWarn>$(NoWarn);CS1591; SA1600</NoWarn>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+      <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>All</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Sandbox.AspNetCore2_1_To_2_2/Startup.cs
+++ b/samples/Sandbox.AspNetCore2_1_To_2_2/Startup.cs
@@ -1,12 +1,13 @@
-﻿using Autofac;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Sandbox.Shared;
 
-namespace Sandbox.AspNetCore2_1_To_2_2
+namespace Sandbox
 {
     public class Startup
     {

--- a/samples/Sandbox.AspNetCore3_To_3_1/Program.cs
+++ b/samples/Sandbox.AspNetCore3_To_3_1/Program.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Sandbox.Shared;
 
 namespace Sandbox
 {

--- a/samples/Sandbox.AspNetCore3_To_3_1/Sandbox.AspNetCore3_To_3_1.csproj
+++ b/samples/Sandbox.AspNetCore3_To_3_1/Sandbox.AspNetCore3_To_3_1.csproj
@@ -2,7 +2,16 @@
     <PropertyGroup>
       <TargetFramework>netcoreapp3.1</TargetFramework>
       <RootNamespace>Sandbox</RootNamespace>
+      <NoWarn>$(NoWarn);CS1591; SA1600</NoWarn>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+      <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>All</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />

--- a/samples/Sandbox.AspNetCore3_To_3_1/Sandbox.AspNetCore3_To_3_1.csproj
+++ b/samples/Sandbox.AspNetCore3_To_3_1/Sandbox.AspNetCore3_To_3_1.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <RootNamespace>Sandbox</RootNamespace>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Sandbox</RootNamespace>
-  </PropertyGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />
-  </ItemGroup>
-
+    <ItemGroup>
+      <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
 </Project>

--- a/samples/Sandbox.AspNetCore3_To_3_1/Startup.cs
+++ b/samples/Sandbox.AspNetCore3_To_3_1/Startup.cs
@@ -1,13 +1,14 @@
-﻿using Autofac;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Sandbox.Shared;
 
 namespace Sandbox
 {
-
     public class Startup
     {
         public void ConfigureServices(IServiceCollection services)

--- a/samples/Sandbox.AspNetCore5/Program.cs
+++ b/samples/Sandbox.AspNetCore5/Program.cs
@@ -1,7 +1,9 @@
-using Microsoft.AspNetCore.Hosting;
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Sandbox.Shared;
 
 namespace Sandbox
 {
@@ -13,7 +15,6 @@ namespace Sandbox
                 .UseServiceProviderFactory(new AutofacMultitenantServiceProviderFactory(MultitenantContainerSetup.ConfigureMultitenantContainer))
                 .ConfigureWebHostDefaults(webHostBuilder => webHostBuilder.UseStartup<Startup>())
                 .Build();
-
 
             await host.RunAsync();
         }

--- a/samples/Sandbox.AspNetCore5/Sandbox.AspNetCore5.csproj
+++ b/samples/Sandbox.AspNetCore5/Sandbox.AspNetCore5.csproj
@@ -9,4 +9,8 @@
       <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
+
 </Project>

--- a/samples/Sandbox.AspNetCore5/Sandbox.AspNetCore5.csproj
+++ b/samples/Sandbox.AspNetCore5/Sandbox.AspNetCore5.csproj
@@ -1,9 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <RootNamespace>Sandbox</RootNamespace>
+        <NoWarn>$(NoWarn);CS1591; SA1600</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>All</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Sandbox.Shared\Sandbox.Shared.csproj" />

--- a/samples/Sandbox.AspNetCore5/Startup.cs
+++ b/samples/Sandbox.AspNetCore5/Startup.cs
@@ -1,8 +1,10 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Autofac;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Sandbox.Shared;
 
 namespace Sandbox
 {

--- a/samples/Sandbox.Shared/ContainerSetup.cs
+++ b/samples/Sandbox.Shared/ContainerSetup.cs
@@ -1,6 +1,9 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Autofac;
 
-namespace Sandbox.Shared
+namespace Sandbox
 {
     public static class ContainerSetup
     {

--- a/samples/Sandbox.Shared/Dependency.cs
+++ b/samples/Sandbox.Shared/Dependency.cs
@@ -1,7 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using Microsoft.Extensions.Logging;
 
-namespace Sandbox.Shared
+namespace Sandbox
 {
     public class Dependency : IDependency, IDisposable
     {

--- a/samples/Sandbox.Shared/IDependency.cs
+++ b/samples/Sandbox.Shared/IDependency.cs
@@ -1,4 +1,7 @@
-﻿namespace Sandbox.Shared
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Sandbox
 {
     public interface IDependency
     {

--- a/samples/Sandbox.Shared/MultitenantContainerSetup.cs
+++ b/samples/Sandbox.Shared/MultitenantContainerSetup.cs
@@ -1,16 +1,19 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Autofac;
 using Autofac.Multitenant;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
-namespace Sandbox.Shared
+namespace Sandbox
 {
     public static class MultitenantContainerSetup
     {
         public static MultitenantContainer ConfigureMultitenantContainer(IContainer container)
         {
-            var strategy = new QueryStringTenantIdentificationStrategy(container.Resolve<IHttpContextAccessor>(),
+            var strategy = new QueryStringTenantIdentificationStrategy(
+                container.Resolve<IHttpContextAccessor>(),
                 container.Resolve<ILogger<QueryStringTenantIdentificationStrategy>>());
 
             var multitenantContainer = new MultitenantContainer(strategy, container);

--- a/samples/Sandbox.Shared/QueryStringTenantIdentificationStrategy.cs
+++ b/samples/Sandbox.Shared/QueryStringTenantIdentificationStrategy.cs
@@ -1,9 +1,12 @@
-﻿using Autofac.Multitenant;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Multitenant;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
-namespace Sandbox.Shared
+namespace Sandbox
 {
     public class QueryStringTenantIdentificationStrategy : ITenantIdentificationStrategy
     {

--- a/samples/Sandbox.Shared/Sandbox.Shared.csproj
+++ b/samples/Sandbox.Shared/Sandbox.Shared.csproj
@@ -1,16 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Sandbox</RootNamespace>
+        <NoWarn>$(NoWarn);CS1591; SA1600</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PrivateAssets>All</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+      <ProjectReference Include="..\..\src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Sandbox.Shared/Sandbox.Shared.csproj
+++ b/samples/Sandbox.Shared/Sandbox.Shared.csproj
@@ -2,14 +2,19 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>Sandbox</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj" />
     </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
-  </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
 
 </Project>

--- a/samples/Sandbox.Shared/ValuesController.cs
+++ b/samples/Sandbox.Shared/ValuesController.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Sandbox.Shared
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sandbox
 {
     [ApiController]
     [Route("api/[controller]")]
@@ -11,12 +14,12 @@ namespace Sandbox.Shared
             Dependency = dependency;
         }
 
+        public IDependency Dependency { get; set; }
+
         [HttpGet]
         public string Get()
         {
             return Dependency.Id;
         }
-
-        public IDependency Dependency { get; set; }
     }
 }

--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -34,6 +34,10 @@
     <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.0" />
   </ItemGroup>

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceCollectionExtensions.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceCollectionExtensions.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2017 Autofac Contributors
-// http://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Autofac;
@@ -50,7 +28,10 @@ namespace Microsoft.AspNetCore.Hosting
         /// </exception>
         public static IServiceCollection AddAutofacMultitenantRequestServices(this IServiceCollection services)
         {
-            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
 
             services.Insert(0, ServiceDescriptor.Transient<IStartupFilter>(provider => new MultitenantRequestServicesStartupFilter()));
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProviderFactory.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantServiceProviderFactory.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2019 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -50,7 +28,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="multitenantContainerAccessor">A function that will access the multitenant container from which request lifetimes should be generated.</param>
         /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the conatiner.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="System.ArgumentNullException">Throws when the multitenant container accessor is null.</exception>
         /// Thrown if <paramref name="multitenantContainerAccessor" /> is <see langword="null" />.
         public AutofacMultitenantServiceProviderFactory(Func<IContainer, MultitenantContainer>? multitenantContainerAccessor, Action<ContainerBuilder>? configurationAction = null)
         {
@@ -81,7 +59,10 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>An <see cref="IServiceProvider" />.</returns>
         public IServiceProvider CreateServiceProvider(ContainerBuilder containerBuilder)
         {
-            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (containerBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(containerBuilder));
+            }
 
             MultitenantContainer multitenantContainer = null!;
 
@@ -91,7 +72,10 @@ namespace Microsoft.AspNetCore.Hosting
 
             multitenantContainer = _multitenantContainerAccessor(containerBuilder.Build());
 
-            if (multitenantContainer == null) throw new InvalidOperationException(Resources.NoMultitenantContainerAvailable);
+            if (multitenantContainer == null)
+            {
+                throw new InvalidOperationException(Resources.NoMultitenantContainerAvailable);
+            }
 
             return new AutofacServiceProvider(multitenantContainer);
         }

--- a/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantWebHostBuilderExtensions.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantWebHostBuilderExtensions.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2017 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Autofac;
@@ -46,7 +24,10 @@ namespace Microsoft.AspNetCore.Hosting
         /// </exception>
         public static IWebHostBuilder UseAutofacMultitenantRequestServices(this IWebHostBuilder builder)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             return builder.ConfigureServices(services =>
             {

--- a/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesMiddleware.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Autofac.Multitenant;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesStartupFilter.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/MultitenantRequestServicesStartupFilter.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using Autofac.Multitenant;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Autofac.Integration.AspNetCore.Multitenant/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Resources;
 using System.Runtime.CompilerServices;
 

--- a/src/Autofac.Integration.AspNetCore.Multitenant/RequestServicesFeatureFactory.cs
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/RequestServicesFeatureFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Autofac.Integration.AspNetCore.Multitenant.Properties;
@@ -11,10 +14,19 @@ using Microsoft.AspNetCore.Hosting.Internal;
 
 namespace Autofac.Integration.AspNetCore.Multitenant
 {
+    /// <summary>
+    /// The factory that is responsible for creating the <see cref="IServiceProvidersFeature"/>.
+    /// </summary>
     internal static class RequestServicesFeatureFactory
     {
         private static readonly Lazy<Func<HttpContext, IServiceScopeFactory, IServiceProvidersFeature>> FactoryFunction = new Lazy<Func<HttpContext, IServiceScopeFactory, IServiceProvidersFeature>>(GenerateLambda);
 
+        /// <summary>
+        /// The function that creates the <see cref="IServiceProvidersFeature"/> based on the framework version.
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/>.</param>
+        /// <param name="scopeFactory">The <see cref="IServiceScopeFactory"/>.</param>
+        /// <returns>An instance of <see cref="IServiceProvidersFeature"/>.</returns>
         public static IServiceProvidersFeature CreateFeature(HttpContext context, IServiceScopeFactory scopeFactory)
         {
             return FactoryFunction.Value.Invoke(context, scopeFactory);

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591; SA1600; SA1633</NoWarn>
+    <NoWarn>$(NoWarn);CS1591; SA1600</NoWarn>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591; SA1600; SA1633</NoWarn>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Autofac.Integration.AspNetCore.Multitenant\Autofac.Integration.AspNetCore.Multitenant.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceCollectionExtensionsTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceCollectionExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using Autofac.Integration.AspNetCore.Multitenant.Properties;
 using Autofac.Multitenant;
 using Microsoft.AspNetCore.Hosting;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceProviderFactoryTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantServiceProviderFactoryTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 using Autofac.Integration.AspNetCore.Multitenant.Properties;
 using Autofac.Multitenant;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantWebHostBuilderExtensionsTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/AutofacMultitenantWebHostBuilderExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using Autofac.Multitenant;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/HostedMultitenancyTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/HostedMultitenancyTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Net;
 using System.Threading.Tasks;
 using Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies;
 using Xunit;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/MultitenantRequestServicesMiddlewareTests.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/MultitenantRequestServicesMiddlewareTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Autofac.Extensions.DependencyInjection;
 using Autofac.Multitenant;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/IScopedDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/IScopedDependency.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 
 namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ITenantAccessor.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ITenantAccessor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 {
     public interface ITenantAccessor

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ScopedDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ScopedDependency.cs
@@ -4,11 +4,11 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 {
     public class ScopedDependency : IScopedDependency
     {
-        public Guid Id { get; }
-
         public ScopedDependency()
         {
             Id = Guid.NewGuid();
         }
+
+        public Guid Id { get; }
     }
 }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ScopedDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/ScopedDependency.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 
 namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TenantAccessorDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TenantAccessorDependency.cs
@@ -4,8 +4,6 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 {
     public sealed class TenantAccessorDependency : ITenantAccessor
     {
-        public string? CurrentTenant { get; }
-
         public TenantAccessorDependency(ITenantIdentificationStrategy tenantIdentificationStrategy)
         {
             if (tenantIdentificationStrategy.TryIdentifyTenant(out var tenantId) &&
@@ -14,5 +12,7 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
                 CurrentTenant = currentTenant;
             }
         }
+
+        public string? CurrentTenant { get; }
     }
 }

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TenantAccessorDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TenantAccessorDependency.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Autofac.Multitenant;
 
 namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestServerFixture.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestServerFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using Autofac.Multitenant;

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestServerFixture.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestServerFixture.cs
@@ -29,6 +29,28 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 
         private sealed class Startup
         {
+            public static MultitenantContainer CreateMultitenantContainer(IContainer container)
+            {
+                var strategy = container.Resolve<ITenantIdentificationStrategy>();
+
+                var mtc = new MultitenantContainer(strategy, container);
+
+                mtc.ConfigureTenant(
+                    "a",
+                    cb => cb
+                        .RegisterType<WhoAmIDependency>()
+                        .WithParameter("id", "a")
+                        .InstancePerLifetimeScope());
+                mtc.ConfigureTenant(
+                    "b",
+                    cb => cb
+                        .RegisterType<WhoAmIDependency>()
+                        .WithParameter("id", "b")
+                        .InstancePerLifetimeScope());
+
+                return mtc;
+            }
+
             public void ConfigureServices(IServiceCollection services)
             {
                 services
@@ -51,28 +73,6 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
             {
                 // You must have ConfigureContainer here, even if it's
                 // not used, or the Autofac container won't be built.
-            }
-
-            public static MultitenantContainer CreateMultitenantContainer(IContainer container)
-            {
-                var strategy = container.Resolve<ITenantIdentificationStrategy>();
-
-                var mtc = new MultitenantContainer(strategy, container);
-
-                mtc.ConfigureTenant(
-                    "a",
-                    cb => cb
-                        .RegisterType<WhoAmIDependency>()
-                        .WithParameter("id", "a")
-                        .InstancePerLifetimeScope());
-                mtc.ConfigureTenant(
-                    "b",
-                    cb => cb
-                        .RegisterType<WhoAmIDependency>()
-                        .WithParameter("id", "b")
-                        .InstancePerLifetimeScope());
-
-                return mtc;
             }
 
             public void Configure(IApplicationBuilder builder)

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestableTenantIdentificationStrategy.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/TestableTenantIdentificationStrategy.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Autofac.Multitenant;
 using Microsoft.AspNetCore.Http;
 

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/WhoAmIDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/WhoAmIDependency.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 {
     public sealed class WhoAmIDependency

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/WhoAmIDependency.cs
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/TestDependencies/WhoAmIDependency.cs
@@ -2,11 +2,11 @@ namespace Autofac.Integration.AspNetCore.Multitenant.Test.TestDependencies
 {
     public sealed class WhoAmIDependency
     {
-        public string Id { get; }
-
         public WhoAmIDependency(string id)
         {
             Id = id;
         }
+
+        public string Id { get; }
     }
 }


### PR DESCRIPTION
* Add latest stylecop rules and configuration based on the once from `Autofac.Diagnostics.Dotgraph`
* Add additional rule to not require `ConfigureAwait(false)`. Since this is ASP.NET Core only and there is no `SynchronizationContext`, there is no need to do that.
* Adjust code that caused warnings according to the latest rules
* Disabled the requirement for commenting and adding license information to test classes (SA1600, SA1633)

Closes #36 