### PR TITLE
feat: add support for .net7

### DIFF
--- a/Autofac.AspNetCore.Multitenant.sln
+++ b/Autofac.AspNetCore.Multitenant.sln
@@ -39,7 +39,7 @@ ProjectSection(SolutionItems) = preProject
 	build\stylecop.json = build\stylecop.json
 EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox.AspNetCore5_To_6", "samples\Sandbox.AspNetCore5_To_6\Sandbox.AspNetCore5_To_6.csproj", "{B64B6D62-AD07-49BE-AF65-3E4C92284AD5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox.AspNetCore5_To_7", "samples\Sandbox.AspNetCore5_To_6\Sandbox.AspNetCore5_To_7.csproj", "{B64B6D62-AD07-49BE-AF65-3E4C92284AD5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,8 @@ version: 6.1.0.{build}
 
 
 dotnet_csproj:
-  version_prefix: "7.0.0"
+  version_prefix: "6.1.0"
+
   patch: true
   file: 'src\**\*.csproj'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: 6.0.0.{build}
+version: 7.0.0.{build}
 
 dotnet_csproj:
-  version_prefix: "6.0.0"
+  version_prefix: "7.0.0"
   patch: true
   file: 'src\**\*.csproj'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 image: Ubuntu
 
-version: 7.0.0.{build}
+version: 6.1.0.{build}
+
 
 dotnet_csproj:
   version_prefix: "7.0.0"

--- a/global.json
+++ b/global.json
@@ -1,10 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "7.0.203",
     "rollForward": "latestFeature"
   },
 
   "additionalSdks": [
+    "6.0.300",
     "5.0.403",
     "3.1.302"
   ]

--- a/samples/Sandbox.AspNetCore5_To_6/Sandbox.AspNetCore5_To_7.csproj
+++ b/samples/Sandbox.AspNetCore5_To_6/Sandbox.AspNetCore5_To_7.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Sandbox</RootNamespace>
     <NoWarn>$(NoWarn);CA1707;CA1848;CS1591;SA1600</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -16,7 +16,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -58,18 +58,18 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) != 'net6.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net5.0' OR $(TargetFramework) == 'netcoreapp3.1'">
     <!-- ServiceCollection moved from M.E.DI to M.E.DI.Abstractions in v6.0.0 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Autofac.Multitenant" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Autofac.Multitenant" Version="7.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">

--- a/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
+++ b/test/Autofac.Integration.AspNetCore.Multitenant.Test/Autofac.Integration.AspNetCore.Multitenant.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1600</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -38,12 +38,12 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -56,6 +56,10 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">


### PR DESCRIPTION
- Add Target framework NET7.0 to src and test projects 
- Change: ItemGroup conditions for Microsoft.Extensions.DependencyInjection so it's only used for .net5.0 and netcoreapp3.1 Update Sandbox project to use NET7.0
- Update appveyor and global.json
- Update a few dependencies