### PR TITLE
Remove obsolete AppVeyor VersionPrefix from csproj

### DIFF
--- a/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
+++ b/src/Autofac.Integration.AspNetCore.Multitenant/Autofac.Integration.AspNetCore.Multitenant.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- VersionPrefix patched by AppVeyor -->
-    <VersionPrefix>0.0.1</VersionPrefix>
     <!-- Assembly metadata -->
     <AssemblyName>Autofac.Integration.AspNetCore.Multitenant</AssemblyName>
     <AssemblyTitle>Autofac.Integration.AspNetCore.Multitenant</AssemblyTitle>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property and associated AppVeyor comment from the source .csproj
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary
- Eliminates risk of accidentally building with a dummy `0.0.1` version outside the normal pipeline

## Test plan
- [ ] CI build passes (version still correctly set by default.proj)
- [ ] Verify produced package has correct version suffix based on branch